### PR TITLE
Use `probe-rs`-based tools in `rtic-testing`

### DIFF
--- a/rtic-testing/.cargo/config
+++ b/rtic-testing/.cargo/config
@@ -1,6 +1,11 @@
-# vim:ft=toml:
-[target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb'
+# Run all bare metal targets using probe-run
+[target.'cfg(all(target_os = "none"))']
+runner = "probe-run --chip atsamd51g19a"
+
+# Enable line table debug info for release builds for probe-run, the
+# generated symbols reside on the host and will not bloat the target binary
+[profile.release]
+debug = 1
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/rtic-testing/Cargo.toml
+++ b/rtic-testing/Cargo.toml
@@ -21,6 +21,8 @@ usbd_scsi = "0.1.0"
 itm_logger = "0.1.2"
 apa102-spi = "0.3.2"
 bitbang-hal = "0.3.2"
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
+panic-probe = "0.2.0"
 
 [features]
 default = ["itsybitsy_m4/usb", "atsamd-hal/usb", "atsamd-hal/samd51g", "atsamd-hal/samd51", "atsamd-hal/unproven"]

--- a/rtic-testing/Embed.toml
+++ b/rtic-testing/Embed.toml
@@ -1,0 +1,9 @@
+[default.general]
+chip = "atsamd51g19a"
+
+[debug.rtt]
+enabled = true
+
+[debug.gdb]
+enabled = true
+gdb_connection_string = "localhost:3333"

--- a/rtic-testing/README.md
+++ b/rtic-testing/README.md
@@ -1,0 +1,77 @@
+# rtic-testing
+
+`rtic-testing` contains various examples and test cases for experimenting with
+and learning the features of [RTIC]. These can be flashed to an
+[Adafruit ItsyBitsy M4 Express] using a [CMSIS-DAP] compatible debug probe.
+
+[RTIC]: https://rtic.rs/dev
+
+[Adafruit ItsyBitsy M4 Express]: https://www.adafruit.com/product/3800
+
+[CMSIS-DAP]: https://arm-software.github.io/CMSIS_5/DAP/html/index.html
+
+## Dependencies
+
+Two `probe-rs` based tools are needed for running/debugging. They have partially
+overlapping feature sets, so it may not be necessary to install both depending
+on your needs. You may `cargo install`
+
+- `probe-run` for flashing the MCU, [RTT I/O] and stack backtraces,
+- `cargo-embed` for flashing the MCU, [RTT I/O] and debugging via [GDB].
+
+[RTT I/O]: https://github.com/probe-rs/probe-rs-rtt
+
+[GDB]: https://www.gnu.org/software/gdb/
+
+### Note: CMSIS-DAP support is currently broken in upstream `probe-rs`
+
+Until [probe-rs/probe-rs#767] has made its way into a release, you may use
+
+```shell
+cargo install --git https://github.com/twelho/probe-run
+cargo install --git https://github.com/twelho/cargo-embed
+```
+
+to install the two dependencies with the patch pre-applied.
+
+[probe-rs/probe-rs#767]: https://github.com/probe-rs/probe-rs/pull/767
+
+## Running
+
+In this directory, with `probe-run` installed, execute
+
+```shell
+cargo run [--release] [--example <example>]
+```
+
+to compile and flash an executable to the MCU. After this `probe-run` will
+automatically attach to RTT I/O so you can interact with the MCU like you would
+with a standard stdin/stdout application running on your host machine. Press
+`CTRL + C` to halt the MCU CPU and exit the monitoring process.
+
+**Note:** In most cases setting up a GDB debug configuration as described below
+is often not needed, since the MCU will output stack backtrace to the host's
+stdout automatically on panic using [RTT I/O] thanks to the `panic_probe`
+panic handler used in these binaries/examples. This feature coupled with direct
+printing to the host using `rprintln!` likely provides a sufficient level of
+debugging.
+
+## Debugging
+
+In this directory, with `cargo-embed` installed, execute
+
+```shell
+cargo embed debug [--example <example>]
+```
+
+to compile and flash an executable to the MCU. After this `cargo-embed` will
+automatically start a GDB server session to which you can attach via
+`localhost:3333` using a multi-arch GDB build supporting the `arm-none-eabi`
+triple (e.g. `arm-none-eabi-gdb` in Arch Linux) or your favorite IDE tooling.
+For example the "Embedded GDB Server" debug target in CLion has been confirmed
+working when using a dummy target specifying `cargo` as the GDB server
+and `embed debug [--example <example>]` as the GDB server args. Don't forget to
+disable uploading and set the correct working directory under the advanced GDB
+server options as well. The GDB server exposed by `cargo-embed` is still
+work-in-progress, so expect bugs and missing features, but for basic breakpoints
+and variable inspection it works quite well already.

--- a/rtic-testing/examples/hello.rs
+++ b/rtic-testing/examples/hello.rs
@@ -16,12 +16,7 @@ use smart_leds::RGB8;
 
 #[entry]
 fn main() -> ! {
-    rtt_init_print!();
-    // hprintln!("Hello, semihosting!").unwrap();
-
-    // exit QEMU
-    // NOTE do not run this on hardware; it can corrupt OpenOCD state
-    // debug::exit(debug::EXIT_SUCCESS);
+    rtt_init_print!(); // Initialize RTT I/O for printing and backtraces
 
     let mut cmp = CMP::take().unwrap();
     let mut peripherals = Peripherals::take().unwrap();
@@ -44,7 +39,7 @@ fn main() -> ! {
 
     let mut rgb = dotstar_bitbang(dotstar, &mut pins.port, SpinTimer::new(12));
     let off: [RGB8; 1] = [RGB8 { r: 0, g: 0, b: 0 }];
-    let on: [RGB8; 1] = [RGB8 { r: 1, g: 1, b: 1 }];
+    let on: [RGB8; 1] = [RGB8 { r: 1, g: 1, b: 1 }]; // Goes up to 255, but honestly this is bright enough
 
     let a: Option<u8> = None;
 

--- a/rtic-testing/examples/hello.rs
+++ b/rtic-testing/examples/hello.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![no_main]
+
+use atsamd_hal::common::timer::SpinTimer;
+use cortex_m::peripheral::Peripherals as CMP;
+use cortex_m::peripheral::SYST;
+use itsybitsy_m4::clock::GenericClockController;
+use itsybitsy_m4::delay::Delay;
+use itsybitsy_m4::pac::Peripherals;
+use itsybitsy_m4::prelude::*;
+use itsybitsy_m4::{dotstar_bitbang, entry};
+use panic_probe as _;
+use rtt_target::{rprintln, rtt_init_print};
+use smart_leds::SmartLedsWrite;
+use smart_leds::RGB8;
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+    // hprintln!("Hello, semihosting!").unwrap();
+
+    // exit QEMU
+    // NOTE do not run this on hardware; it can corrupt OpenOCD state
+    // debug::exit(debug::EXIT_SUCCESS);
+
+    let mut cmp = CMP::take().unwrap();
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let mut pins = itsybitsy_m4::Pins::new(peripherals.PORT);
+    let mut delay = Delay::new(cmp.SYST, &mut clocks);
+
+    let dotstar = itsybitsy_m4::pins::Dotstar {
+        ci: pins.dotstar_ci,
+        di: pins.dotstar_di,
+        nc: pins.dotstar_nc,
+    };
+
+    let mut rgb = dotstar_bitbang(dotstar, &mut pins.port, SpinTimer::new(12));
+    let off: [RGB8; 1] = [RGB8 { r: 0, g: 0, b: 0 }];
+    let on: [RGB8; 1] = [RGB8 { r: 1, g: 1, b: 1 }];
+
+    let a: Option<u8> = None;
+
+    loop {
+        // a.unwrap(); // Uncomment to test stack backtrace output
+        rprintln!("Hello, world!");
+        rgb.write(on.iter().cloned()).unwrap();
+        delay.delay_ms(500u32);
+        rgb.write(off.iter().cloned()).unwrap();
+        delay.delay_ms(500u32);
+    }
+}

--- a/rtic-testing/memory.x
+++ b/rtic-testing/memory.x
@@ -1,7 +1,6 @@
 MEMORY
 {
-  /* Leave 16k for the default bootloader on the ItsyBitsy M4 */
-  FLASH (rx) : ORIGIN = 0x00000000 + 16K, LENGTH = 512K - 16K
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 512K
   RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 192K
 }
 _stack_start = ORIGIN(RAM) + LENGTH(RAM);

--- a/rtic-testing/openocd.cfg
+++ b/rtic-testing/openocd.cfg
@@ -1,2 +1,34 @@
-source [find interface/jlink.cfg]
+# ST-LINK interface driver
+#source [find interface/stlink.cfg]
+
+# FTDI interface driver
+#source [find interface/ftdi/ft232h-module-swd.cfg]
+
+# CMSIS-DAP interface driver (dap42 uses HID mode)
+source [find interface/cmsis-dap.cfg]
+cmsis_dap_backend hid
+transport select swd
+
+# Raspberry Pi GPIO bitbang driver
+#source [find interface/raspberrypi-native.cfg]
+
+# 128K Flash size override for STM32F103C8
+#set FLASH_SIZE 131072
+
+# ID override for ST-LINK stock firmware
+#set CPUTAPID 0
+
+# ST-LINK V2 (clone) target
+#set CHIPNAME stm32f103c8t6
+#source [find target/stm32f1x.cfg]
+
+# Adafruit ItsyBitsy M4 target
+set CHIPNAME atsamd51g19a
 source [find target/atsame5x.cfg]
+
+# Manual clock speed override
+#adapter speed 1000
+
+init
+targets
+reset halt

--- a/rtic-testing/openocd.cfg
+++ b/rtic-testing/openocd.cfg
@@ -4,7 +4,12 @@
 # FTDI interface driver
 #source [find interface/ftdi/ft232h-module-swd.cfg]
 
-# CMSIS-DAP interface driver (dap42 uses HID mode)
+# CMSIS-DAP interface driver
+# CMSIS-DAP v1 uses HID generic reports ("hid" backend), while CMSIS-DAP v2
+# uses USB bulk transfers ("usb_bulk" backend). Most current CMSIS-DAP
+# implementations use "hid" mode, including the recommended dap42 firmware.
+# OpenOCD also supports automatic backend detection, but it is a bit unreliable
+# so it's better to specify it here explicitly.
 source [find interface/cmsis-dap.cfg]
 cmsis_dap_backend hid
 transport select swd


### PR DESCRIPTION
Implements the runtime/debugging configuration presented in https://github.com/racklet/bmc-experiments/pull/3. Also adds a new example for showing off RTT I/O and checking that everything works. I'm not the biggest fan of having to hard code the chip used in `.cargo/config` and `Embed.toml`, but there might be some ways to improve this later. We could for example set the environment variable `PROBE_RUN_CHIP` using the new [`configurable-env`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#configurable-env) feature of Cargo that was stabilized in 1.56 for the first case and writing the `default.general.chip` definition to `Embed.local.toml` using a `build.rs` file for the second.

Also, the bootloader shipped with the ItsyBitsy M4 is now useless, so I've deleted the offset from `memory.x`.

cc @luxas @chiplet 